### PR TITLE
build: bump CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This is just the minimum subset needed for building an embedded
 # static library into Transmission.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(psl
   VERSION 0.21.1.0 # when changing this, must set LIBPSL_VERSION_NUMBER too


### PR DESCRIPTION
CMake < 3.5 compatibility has been removed from CMake 4.0 and CMake < 3.10 compatibility has been deprecated in CMake 3.31.

https://cmake.org/cmake/help/latest/release/4.0.html
https://cmake.org/cmake/help/latest/release/3.31.html